### PR TITLE
Make 'media' field nullable in ProjectController

### DIFF
--- a/app/Http/Controllers/Dashboard/ProjectController.php
+++ b/app/Http/Controllers/Dashboard/ProjectController.php
@@ -63,7 +63,7 @@ class ProjectController extends Controller
             'content'           => 'nullable|string',
             'category_id'       => 'nullable|exists:categories,id',
             'is_selected_work'  => 'nullable|boolean',
-            'media'             => 'array',
+            'media'             => 'nullable|array',
             'media.*'           => 'exists:media,id',
         ]);
 
@@ -166,7 +166,7 @@ class ProjectController extends Controller
             'content'           => 'nullable|string',
             'category_id'       => 'nullable|exists:categories,id',
             'is_selected_work'  => 'nullable|boolean',
-            'media'             => 'array',
+            'media'             => 'nullable|array',
             'media.*'           => 'exists:media,id',
         ]);
 

--- a/public/hot
+++ b/public/hot
@@ -1,0 +1,1 @@
+http://localhost:5173


### PR DESCRIPTION
Updated validation rules in ProjectController to allow the 'media' field to be nullable when creating or updating a project. Also added the 'public/hot' file for local development server configuration.