### PR TITLE
Add thumbnail support to projects

### DIFF
--- a/app/Http/Controllers/Dashboard/ProjectController.php
+++ b/app/Http/Controllers/Dashboard/ProjectController.php
@@ -65,6 +65,7 @@ class ProjectController extends Controller
             'is_selected_work'  => 'nullable|boolean',
             'media'             => 'nullable|array',
             'media.*'           => 'exists:media,id',
+            'thumbnail_id'      => 'nullable|exists:media,id',
         ]);
 
         $validated['slug'] = $validated['slug'] ?: Str::slug($validated['title']);
@@ -84,6 +85,7 @@ class ProjectController extends Controller
             'content'           => $validated['content'] ?? null,
             'category_id'       => $validated['category_id'] ?? null,
             'is_selected_work'  => $request->boolean('is_selected_work'),
+            'thumbnail_id'      => $validated['thumbnail_id'] ?? null,
         ]);
 
         // Attacher les médias si présents
@@ -168,6 +170,7 @@ class ProjectController extends Controller
             'is_selected_work'  => 'nullable|boolean',
             'media'             => 'nullable|array',
             'media.*'           => 'exists:media,id',
+            'thumbnail_id'      => 'nullable|exists:media,id',
         ]);
 
         $validated['slug'] = $validated['slug'] ?: Str::slug($validated['title']);
@@ -179,6 +182,7 @@ class ProjectController extends Controller
             'content'           => $validated['content'] ?? null,
             'category_id'       => $validated['category_id'] ?? null,
             'is_selected_work'  => $request->boolean('is_selected_work'),
+            'thumbnail_id'      => $validated['thumbnail_id'] ?? null,
         ]);
 
         // Synchroniser les médias

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -15,6 +15,7 @@ class Project extends Model
         'category_order',
         'is_selected_work',
         'is_locked',
+        'thumbnail_id',
     ];
 
     protected $casts = [
@@ -25,6 +26,11 @@ class Project extends Model
     public function media()
     {
         return $this->belongsToMany(Media::class);
+    }
+
+    public function thumbnail()
+    {
+        return $this->belongsTo(Media::class, 'thumbnail_id');
     }
 
     public function pages() {

--- a/database/migrations/2025_11_04_125833_add_thumbnail_support_to_projects_table.php
+++ b/database/migrations/2025_11_04_125833_add_thumbnail_support_to_projects_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->foreignId('thumbnail_id')->nullable()->after('slug')->constrained('media')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropForeign(['thumbnail_id']);
+            $table->dropColumn('thumbnail_id');
+        });
+    }
+};

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -18,33 +18,37 @@
             <div class="flex flex-wrap justify-center gap-4 px-6">
                 @foreach ($projects as $project)
                     @php
-                        // Sélectionner le média avec le meilleur ratio pour remplir l'espace
-                        $idealRatio = 1.5; // Ratio idéal pour un bon remplissage
-                        $bestMedia = null;
-                        $bestScore = PHP_FLOAT_MAX;
+                        // Utiliser la thumbnail si elle existe, sinon sélectionner le média avec le meilleur ratio
+                        if ($project->thumbnail) {
+                            $media = $project->thumbnail;
+                        } else {
+                            $idealRatio = 1.5; // Ratio idéal pour un bon remplissage
+                            $bestMedia = null;
+                            $bestScore = PHP_FLOAT_MAX;
 
-                        foreach ($project->media as $media) {
-                            $ratio = 1.77; // ratio par défaut
-                            if (Str::startsWith($media->type, 'image/')) {
-                                $imagePath = storage_path("app/public/" . $media->file_path);
-                                if (file_exists($imagePath)) {
-                                    [$width, $height] = getimagesize($imagePath);
-                                    $ratio = $width / $height;
+                            foreach ($project->media as $mediaItem) {
+                                $ratio = 1.77; // ratio par défaut
+                                if (Str::startsWith($mediaItem->type, 'image/')) {
+                                    $imagePath = storage_path("app/public/" . $mediaItem->file_path);
+                                    if (file_exists($imagePath)) {
+                                        [$width, $height] = getimagesize($imagePath);
+                                        $ratio = $width / $height;
+                                    }
+                                }
+
+                                // Calculer la différence avec le ratio idéal
+                                $score = abs($ratio - $idealRatio);
+                                if ($score < $bestScore) {
+                                    $bestScore = $score;
+                                    $bestMedia = $mediaItem;
                                 }
                             }
 
-                            // Calculer la différence avec le ratio idéal
-                            $score = abs($ratio - $idealRatio);
-                            if ($score < $bestScore) {
-                                $bestScore = $score;
-                                $bestMedia = $media;
-                            }
+                            $media = $bestMedia ?: $project->media->first();
                         }
-
-                        $media = $bestMedia ?: $project->media->first();
                     @endphp
-                    @if ($media)
-                        <a href="{{ route('pages.show', $project->slug) }}" class="block relative h-60 max-w-[40%] min-w-[15%] group overflow-hidden">
+                    <a href="{{ route('pages.show', $project->slug) }}" class="block relative h-60 max-w-[40%] min-w-[15%] group overflow-hidden">
+                        @if ($media)
                             @if (Str::startsWith($media->type, 'image/'))
                                 <img
                                     src="{{ asset('storage/' . $media->file_path) }}"
@@ -66,14 +70,21 @@
                                     muted autoplay loop
                                 ></video>
                             @endif
-                            {{-- Overlay discret en bas à gauche avec slide in --}}
-                            <div class="absolute bottom-3 left-3 bg-white bg-opacity-90 backdrop-blur-sm rounded-sm px-2 py-1 transform translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
-                                <span class="text-gray-900 font-medium text-sm">
-                                    {{ $project->title }}
-                                </span>
+                        @else
+                            {{-- Placeholder gris si aucun média --}}
+                            <div class="h-full w-48 bg-gray-300 rounded-none shadow mx-auto flex items-center justify-center">
+                                <svg class="w-16 h-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
                             </div>
-                        </a>
-                    @endif
+                        @endif
+                        {{-- Overlay discret en bas à gauche avec slide in --}}
+                        <div class="absolute bottom-3 left-3 bg-white bg-opacity-90 backdrop-blur-sm rounded-sm px-2 py-1 transform translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
+                            <span class="text-gray-900 font-medium text-sm">
+                                {{ $project->title }}
+                            </span>
+                        </div>
+                    </a>
                 @endforeach
             </div>
         @else

--- a/resources/views/dashboard/projects/create.blade.php
+++ b/resources/views/dashboard/projects/create.blade.php
@@ -227,6 +227,22 @@
                         </div>
                     </div>
 
+                    {{-- Info sur la thumbnail --}}
+                    <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                        <div class="flex items-start">
+                            <svg class="w-5 h-5 text-blue-600 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path>
+                            </svg>
+                            <div>
+                                <h4 class="font-medium text-blue-900 text-sm">Thumbnail du projet</h4>
+                                <p class="text-sm text-blue-700 mt-1">
+                                    Vous pourrez sélectionner une thumbnail après avoir créé le projet et attaché des médias.
+                                    Rendez-vous dans l'édition du projet pour choisir l'image qui représentera ce projet.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="flex justify-end pt-4">
                         <button type="submit" class="inline-flex items-center px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors duration-200 font-medium">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/resources/views/dashboard/projects/edit.blade.php
+++ b/resources/views/dashboard/projects/edit.blade.php
@@ -215,6 +215,186 @@
                         </div>
                     </div>
 
+                    {{-- Sélection de la thumbnail --}}
+                    <div class="mb-8">
+                        <label class="block font-medium text-sm text-gray-700 mb-4">
+                            Thumbnail du projet
+                            <span class="text-xs text-gray-500 font-normal ml-2">(Cliquez sur un dossier pour voir ses médias)</span>
+                        </label>
+
+                        <div id="thumbnail-selector" class="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                            <p class="text-sm text-gray-600 mb-4">La thumbnail sera utilisée pour représenter ce projet sur les pages de catégorie et la page d'accueil.</p>
+
+                            @php
+                                $currentThumbnailId = old('thumbnail_id', $project->thumbnail_id);
+                            @endphp
+
+                            {{-- Option: Pas de thumbnail --}}
+                            <div class="mb-4">
+                                <label class="relative cursor-pointer group inline-block">
+                                    <input type="radio" name="thumbnail_id" value=""
+                                           class="peer hidden"
+                                           {{ !$currentThumbnailId ? 'checked' : '' }}>
+
+                                    <div class="w-32 h-32 flex items-center justify-center rounded-md border-2 border-dashed border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition bg-white">
+                                        <div class="text-center">
+                                            <svg class="w-8 h-8 mx-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                            </svg>
+                                            <p class="text-xs text-gray-500 mt-1">Aucune</p>
+                                        </div>
+                                    </div>
+                                    <div class="absolute inset-0 rounded-md bg-indigo-500/20 opacity-0 peer-checked:opacity-100 transition pointer-events-none"></div>
+                                </label>
+                            </div>
+
+                            {{-- Liste des dossiers pliables --}}
+                            <div class="space-y-2">
+                                {{-- Dossiers existants --}}
+                                @foreach($folders as $folder)
+                                    @if($folder->media->count() > 0)
+                                        <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
+                                            <button type="button"
+                                                    onclick="toggleThumbnailFolder('folder-{{ $folder->id }}')"
+                                                    class="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50 transition-colors">
+                                                <div class="flex items-center">
+                                                    <svg class="w-5 h-5 mr-3 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+                                                        <path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/>
+                                                    </svg>
+                                                    <span class="font-medium text-gray-900">{{ $folder->name }}</span>
+                                                    <span class="ml-2 text-xs text-gray-500">({{ $folder->media->count() }} médias)</span>
+                                                </div>
+                                                <svg class="w-5 h-5 text-gray-400 transform transition-transform" id="icon-folder-{{ $folder->id }}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                                </svg>
+                                            </button>
+
+                                            <div id="folder-{{ $folder->id }}" class="hidden px-4 pb-4">
+                                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 pt-3 border-t border-gray-100">
+                                                    @foreach($folder->media as $item)
+                                                        <label class="relative cursor-pointer group">
+                                                            <input type="radio" name="thumbnail_id" value="{{ $item->id }}"
+                                                                   class="peer hidden"
+                                                                   {{ $currentThumbnailId == $item->id ? 'checked' : '' }}>
+
+                                                            @if(Str::startsWith($item->type, 'image/'))
+                                                                <img src="{{ asset('storage/' . $item->file_path) }}"
+                                                                     alt="thumbnail option"
+                                                                     class="w-full h-32 object-cover rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition">
+                                                            @elseif($item->is_external)
+                                                                <div class="w-full h-32 rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition overflow-hidden">
+                                                                    <iframe src="{{ $item->getEmbedUrl() }}"
+                                                                            class="w-full h-full pointer-events-none"
+                                                                            frameborder="0"></iframe>
+                                                                </div>
+                                                            @elseif(Str::startsWith($item->type, 'video/'))
+                                                                <video class="w-full h-32 object-cover rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition" muted>
+                                                                    <source src="{{ asset('storage/' . $item->file_path) }}" type="{{ $item->type }}">
+                                                                </video>
+                                                            @endif
+
+                                                            <div class="absolute inset-0 rounded-md bg-indigo-500/20 opacity-0 peer-checked:opacity-100 transition pointer-events-none"></div>
+
+                                                            <div class="absolute top-2 right-2 opacity-0 peer-checked:opacity-100 transition-opacity">
+                                                                <div class="p-1 rounded-full bg-indigo-500">
+                                                                    <svg class="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+                                                                    </svg>
+                                                                </div>
+                                                            </div>
+                                                        </label>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @endif
+                                @endforeach
+
+                                {{-- Médias non organisés --}}
+                                @if($media->count() > 0)
+                                    <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
+                                        <button type="button"
+                                                onclick="toggleThumbnailFolder('folder-unorganized')"
+                                                class="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50 transition-colors">
+                                            <div class="flex items-center">
+                                                <svg class="w-5 h-5 mr-3 text-gray-600" fill="currentColor" viewBox="0 0 24 24">
+                                                    <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                                                </svg>
+                                                <span class="font-medium text-gray-900">Médias non organisés</span>
+                                                <span class="ml-2 text-xs text-gray-500">({{ $media->count() }} médias)</span>
+                                            </div>
+                                            <svg class="w-5 h-5 text-gray-400 transform transition-transform" id="icon-folder-unorganized" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                            </svg>
+                                        </button>
+
+                                        <div id="folder-unorganized" class="hidden px-4 pb-4">
+                                            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 pt-3 border-t border-gray-100">
+                                                @foreach($media as $item)
+                                                    <label class="relative cursor-pointer group">
+                                                        <input type="radio" name="thumbnail_id" value="{{ $item->id }}"
+                                                               class="peer hidden"
+                                                               {{ $currentThumbnailId == $item->id ? 'checked' : '' }}>
+
+                                                        @if(Str::startsWith($item->type, 'image/'))
+                                                            <img src="{{ asset('storage/' . $item->file_path) }}"
+                                                                 alt="thumbnail option"
+                                                                 class="w-full h-32 object-cover rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition">
+                                                        @elseif($item->is_external)
+                                                            <div class="w-full h-32 rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition overflow-hidden">
+                                                                <iframe src="{{ $item->getEmbedUrl() }}"
+                                                                        class="w-full h-full pointer-events-none"
+                                                                        frameborder="0"></iframe>
+                                                            </div>
+                                                        @elseif(Str::startsWith($item->type, 'video/'))
+                                                            <video class="w-full h-32 object-cover rounded-md border-2 border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 transition" muted>
+                                                                <source src="{{ asset('storage/' . $item->file_path) }}" type="{{ $item->type }}">
+                                                            </video>
+                                                        @endif
+
+                                                        <div class="absolute inset-0 rounded-md bg-indigo-500/20 opacity-0 peer-checked:opacity-100 transition pointer-events-none"></div>
+
+                                                        <div class="absolute top-2 right-2 opacity-0 peer-checked:opacity-100 transition-opacity">
+                                                            <div class="p-1 rounded-full bg-indigo-500">
+                                                                <svg class="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                                                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </label>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endif
+                            </div>
+
+                            @if($folders->count() == 0 && $media->count() == 0)
+                                <p class="text-sm text-amber-600 mt-3">
+                                    <svg class="w-4 h-4 inline mr-1" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
+                                    </svg>
+                                    Aucun média disponible. Ajoutez des médias dans la section Gestion des Médias.
+                                </p>
+                            @endif
+                        </div>
+                    </div>
+
+                    <script>
+                        function toggleThumbnailFolder(folderId) {
+                            const folder = document.getElementById(folderId);
+                            const icon = document.getElementById('icon-' + folderId);
+
+                            if (folder.classList.contains('hidden')) {
+                                folder.classList.remove('hidden');
+                                icon.style.transform = 'rotate(180deg)';
+                            } else {
+                                folder.classList.add('hidden');
+                                icon.style.transform = 'rotate(0deg)';
+                            }
+                        }
+                    </script>
+
                     {{-- Bouton --}}
                     <div class="flex justify-end">
                         <button type="submit"

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -18,34 +18,38 @@
             <div class="flex flex-wrap justify-center gap-4 px-6">
                             @foreach ($selectedWorkProjects as $project)
                                 @php
-                                    // Sélectionner le média avec le meilleur ratio pour remplir l'espace
-                                    $idealRatio = 1.5; // Ratio idéal pour un bon remplissage
-                                    $bestMedia = null;
-                                    $bestScore = PHP_FLOAT_MAX;
+                                    // Utiliser la thumbnail si elle existe, sinon sélectionner le média avec le meilleur ratio
+                                    if ($project->thumbnail) {
+                                        $media = $project->thumbnail;
+                                    } else {
+                                        $idealRatio = 1.5; // Ratio idéal pour un bon remplissage
+                                        $bestMedia = null;
+                                        $bestScore = PHP_FLOAT_MAX;
 
-                                    foreach ($project->media as $media) {
-                                        $ratio = 1.77; // ratio par défaut
-                                        if (Str::startsWith($media->type, 'image/')) {
-                                            $imagePath = storage_path("app/public/" . $media->file_path);
-                                            if (file_exists($imagePath)) {
-                                                [$width, $height] = getimagesize($imagePath);
-                                                $ratio = $width / $height;
+                                        foreach ($project->media as $mediaItem) {
+                                            $ratio = 1.77; // ratio par défaut
+                                            if (Str::startsWith($mediaItem->type, 'image/')) {
+                                                $imagePath = storage_path("app/public/" . $mediaItem->file_path);
+                                                if (file_exists($imagePath)) {
+                                                    [$width, $height] = getimagesize($imagePath);
+                                                    $ratio = $width / $height;
+                                                }
+                                            }
+
+                                            // Calculer la différence avec le ratio idéal
+                                            $score = abs($ratio - $idealRatio);
+                                            if ($score < $bestScore) {
+                                                $bestScore = $score;
+                                                $bestMedia = $mediaItem;
                                             }
                                         }
 
-                                        // Calculer la différence avec le ratio idéal
-                                        $score = abs($ratio - $idealRatio);
-                                        if ($score < $bestScore) {
-                                            $bestScore = $score;
-                                            $bestMedia = $media;
-                                        }
+                                        $media = $bestMedia ?: $project->media->first();
                                     }
-
-                                    $media = $bestMedia ?: $project->media->first();
                                 @endphp
-                                @if ($media)
-                                    {{-- Responsive sizing: pleine largeur sur mobile, puis adaptatif --}}
-                                    <a href="{{ route('pages.show', $project->slug) }}" class="block relative h-60 max-w-[40%] min-w-[15%] group overflow-hidden">
+                                {{-- Responsive sizing: pleine largeur sur mobile, puis adaptatif --}}
+                                <a href="{{ route('pages.show', $project->slug) }}" class="block relative h-60 max-w-[40%] min-w-[15%] group overflow-hidden">
+                                    @if ($media)
                                         @if (Str::startsWith($media->type, 'image/'))
                                             <img
                                                 src="{{ asset('storage/' . $media->file_path) }}"
@@ -67,14 +71,21 @@
                                                 muted autoplay loop
                                             ></video>
                                         @endif
-                                        {{-- Overlay discret en bas à gauche avec slide in --}}
-                                        <div class="absolute bottom-3 left-3 bg-white bg-opacity-90 backdrop-blur-sm rounded-sm px-2 py-1 transform translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
-                                            <span class="text-gray-900 font-medium text-xs sm:text-sm">
-                                                {{ $project->title }}
-                                            </span>
+                                    @else
+                                        {{-- Placeholder gris si aucun média --}}
+                                        <div class="h-full w-48 bg-gray-300 rounded-none shadow mx-auto flex items-center justify-center">
+                                            <svg class="w-16 h-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                            </svg>
                                         </div>
-                                    </a>
-                                @endif
+                                    @endif
+                                    {{-- Overlay discret en bas à gauche avec slide in --}}
+                                    <div class="absolute bottom-3 left-3 bg-white bg-opacity-90 backdrop-blur-sm rounded-sm px-2 py-1 transform translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300">
+                                        <span class="text-gray-900 font-medium text-xs sm:text-sm">
+                                            {{ $project->title }}
+                                        </span>
+                                    </div>
+                                </a>
                             @endforeach
                         </div>
         @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,8 +14,8 @@ use App\Models\Project;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
-    $selectedWorkProjects = \App\Models\Project::where('is_selected_work', true)->with('media')->get();
-    
+    $selectedWorkProjects = \App\Models\Project::where('is_selected_work', true)->with(['media', 'thumbnail'])->get();
+
     return view('home', compact('selectedWorkProjects'));
 });
 
@@ -78,8 +78,8 @@ Route::get('/pages/{slug}', [PageController::class, 'show'])->name('pages.show')
 Route::get('/categories/{slug}', function (string $slug) {
     $category = Category::where('name', $slug)->firstOrFail();
 
-    // Récupérer tous les projets de cette catégorie avec leurs médias, triés par category_order
-    $projects = $category->projects()->with('media')->orderBy('category_order')->get();
+    // Récupérer tous les projets de cette catégorie avec leurs médias et thumbnails, triés par category_order
+    $projects = $category->projects()->with(['media', 'thumbnail'])->orderBy('category_order')->get();
 
     return view('categories.show', compact('category', 'projects'));
 })->name('categories.show');


### PR DESCRIPTION
Introduces thumbnail selection for projects by adding a nullable thumbnail_id foreign key to the projects table, updating the Project model with a thumbnail relationship, and modifying controllers and views to handle thumbnail selection and display. The dashboard now allows users to choose a thumbnail from attached media, and category/home views prioritize the thumbnail for project representation.